### PR TITLE
Set default read message limit to 4MB and check before compression

### DIFF
--- a/conformance/test/gen/connectrpc/conformance/v1/service_connect.py
+++ b/conformance/test/gen/connectrpc/conformance/v1/service_connect.py
@@ -12,7 +12,7 @@ from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.method import IdempotencyLevel, MethodInfo
-from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
+from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from protobuf import DescService
 
 from . import service_pb
@@ -180,7 +180,7 @@ class ConformanceServiceASGIApplication(ConnectASGIApplication[ConformanceServic
         service: ConformanceService | AsyncGenerator[ConformanceService],
         *,
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -658,7 +658,7 @@ class ConformanceServiceWSGIApplication(ConnectWSGIApplication):
         self,
         service: ConformanceServiceSync,
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:

--- a/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1/reflection_connect.py
+++ b/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1/reflection_connect.py
@@ -12,7 +12,7 @@ from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.method import IdempotencyLevel, MethodInfo
-from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
+from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from protobuf import DescService
 
 from . import reflection_pb
@@ -46,7 +46,7 @@ class ServerReflectionASGIApplication(ConnectASGIApplication[ServerReflection]):
         service: ServerReflection | AsyncGenerator[ServerReflection],
         *,
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -119,7 +119,7 @@ class ServerReflectionWSGIApplication(ConnectWSGIApplication):
         self,
         service: ServerReflectionSync,
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:

--- a/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1alpha/reflection_connect.py
+++ b/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1alpha/reflection_connect.py
@@ -12,7 +12,7 @@ from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.method import IdempotencyLevel, MethodInfo
-from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
+from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from protobuf import DescService
 
 from . import reflection_pb
@@ -46,7 +46,7 @@ class ServerReflectionASGIApplication(ConnectASGIApplication[ServerReflection]):
         service: ServerReflection | AsyncGenerator[ServerReflection],
         *,
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -119,7 +119,7 @@ class ServerReflectionWSGIApplication(ConnectWSGIApplication):
         self,
         service: ServerReflectionSync,
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:

--- a/connectrpc-grpcreflect/test/connectrpc/example/haberdasher_connect.py
+++ b/connectrpc-grpcreflect/test/connectrpc/example/haberdasher_connect.py
@@ -12,7 +12,7 @@ from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.method import IdempotencyLevel, MethodInfo
-from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
+from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from protobuf import DescService
 from protobuf.wkt import Empty
 
@@ -76,7 +76,7 @@ class HaberdasherASGIApplication(ConnectASGIApplication[Haberdasher]):
         service: Haberdasher | AsyncGenerator[Haberdasher],
         *,
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -344,7 +344,7 @@ class HaberdasherWSGIApplication(ConnectWSGIApplication):
         self,
         service: HaberdasherSync,
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:

--- a/example/example/gen/connectrpc/eliza/v1/eliza_connect.py
+++ b/example/example/gen/connectrpc/eliza/v1/eliza_connect.py
@@ -12,7 +12,7 @@ from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.method import IdempotencyLevel, MethodInfo
-from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
+from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from protobuf import DescService
 
 from . import eliza_pb
@@ -68,7 +68,7 @@ class ElizaServiceASGIApplication(ConnectASGIApplication[ElizaService]):
         service: ElizaService | AsyncGenerator[ElizaService],
         *,
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -241,7 +241,7 @@ class ElizaServiceWSGIApplication(ConnectWSGIApplication):
         self,
         service: ElizaServiceSync,
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:

--- a/protoc-gen-connectrpc/protoc_gen_connectrpc/__init__.py
+++ b/protoc-gen-connectrpc/protoc_gen_connectrpc/__init__.py
@@ -67,6 +67,7 @@ _REQUEST_CONTEXT = _CONNECTRPC_REQUEST.ident("RequestContext", type_only=True)
 _CONNECTRPC_PROTOCOL = Module("connectrpc.protocol")
 _PROTOCOL_TYPE = _CONNECTRPC_PROTOCOL.ident("ProtocolType")
 _CONNECTRPC_SERVER = Module("connectrpc.server")
+_DEFAULT_READ_MAX_BYTES = _CONNECTRPC_SERVER.ident("DEFAULT_READ_MAX_BYTES")
 _ENDPOINT = _CONNECTRPC_SERVER.ident("Endpoint")
 _ENDPOINT_SYNC = _CONNECTRPC_SERVER.ident("EndpointSync")
 _CONNECT_ASGI_APPLICATION = _CONNECTRPC_SERVER.ident("ConnectASGIApplication")
@@ -198,7 +199,7 @@ def _generate_async_stubs(f: File, service: DescService, options: Options) -> No
             )
             f.print("*,")
             f.print("interceptors: ", _ITERABLE, "[", _INTERCEPTOR, "] = (),")
-            f.print("read_max_bytes: int | None = None,")
+            f.print("read_max_bytes: int | None = ", _DEFAULT_READ_MAX_BYTES, ",")
             f.print("compressions: ", _ITERABLE, "[", _COMPRESSION, "] | None = None,")
             f.print(
                 "codecs: ",
@@ -369,7 +370,7 @@ def _generate_sync_stubs(f: File, service: DescService, options: Options) -> Non
             f.print("self,")
             f.print("service: ", service_name, "Sync,")
             f.print("interceptors: ", _ITERABLE, "[", _INTERCEPTOR_SYNC, "] = (),")
-            f.print("read_max_bytes: int | None = None,")
+            f.print("read_max_bytes: int | None = ", _DEFAULT_READ_MAX_BYTES, ",")
             f.print("compressions: ", _ITERABLE, "[", _COMPRESSION, "] | None = None,")
             f.print(
                 "codecs: ", _ITERABLE, "[", _CODEC, "] | None = ", default_codecs, ","

--- a/src/connectrpc/_envelope.py
+++ b/src/connectrpc/_envelope.py
@@ -82,6 +82,14 @@ class EnvelopeReader(Generic[_RES]):
                 return
 
             self._next_message_length = int.from_bytes(self._buffer[1:5], "big")
+            if (
+                self._read_max_bytes is not None
+                and self._next_message_length > self._read_max_bytes
+            ):
+                raise ConnectError(
+                    Code.RESOURCE_EXHAUSTED,
+                    f"message is larger than configured max {self._read_max_bytes}",
+                )
 
     def handle_end_message(
         self, _prefix_byte: int, _message_data: bytes | bytearray, /

--- a/src/connectrpc/_server_async.py
+++ b/src/connectrpc/_server_async.py
@@ -26,6 +26,7 @@ from ._protocol import ConnectWireError, HTTPError, ServerProtocol
 from ._protocol_connect import CONNECT_UNARY_CONTENT_TYPE_PREFIX, ConnectServerProtocol
 from ._protocol_server import negotiate_server_protocol
 from ._server_shared import (
+    DEFAULT_READ_MAX_BYTES,
     EndpointBidiStream,
     EndpointClientStream,
     EndpointServerStream,
@@ -89,7 +90,7 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
         service: _SVC | AsyncGenerator[_SVC],
         endpoints: Callable[[_SVC], Mapping[str, Endpoint]],
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -342,7 +343,16 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
     ) -> _REQ:
         """Handle POST request with body."""
         # Get request body
-        chunks: list[bytes] = [chunk async for chunk in _read_body(receive)]
+        chunks: list[bytes] = []
+        read_bytes = 0
+        async for chunk in _read_body(receive):
+            read_bytes += len(chunk)
+            if self._read_max_bytes is not None and read_bytes > self._read_max_bytes:
+                raise ConnectError(
+                    Code.RESOURCE_EXHAUSTED,
+                    f"message is larger than configured max {self._read_max_bytes}",
+                )
+            chunks.append(chunk)
         req_body = b"".join(chunks)
 
         # Handle compression if specified

--- a/src/connectrpc/_server_shared.py
+++ b/src/connectrpc/_server_shared.py
@@ -14,6 +14,9 @@ RES = TypeVar("RES")
 T = TypeVar("T")
 U = TypeVar("U")
 
+DEFAULT_READ_MAX_BYTES = 1024 * 1024 * 4  # 4 MB
+"""The default maximum size of a request message (4MB)."""
+
 
 @dataclass(kw_only=True, frozen=True, slots=True)
 class Endpoint(Generic[REQ, RES]):

--- a/src/connectrpc/_server_sync.py
+++ b/src/connectrpc/_server_sync.py
@@ -30,6 +30,7 @@ from ._protocol_connect import (
 )
 from ._protocol_server import negotiate_server_protocol
 from ._server_shared import (
+    DEFAULT_READ_MAX_BYTES,
     EndpointBidiStreamSync,
     EndpointClientStreamSync,
     EndpointServerStreamSync,
@@ -156,7 +157,7 @@ class ConnectWSGIApplication(ABC):
         *,
         endpoints: Mapping[str, EndpointSync],
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -306,9 +307,30 @@ class ConnectWSGIApplication(ABC):
             content_length = environ.get("CONTENT_LENGTH")
             content_length = 0 if not content_length else int(content_length)
             if content_length > 0:
+                if (
+                    self._read_max_bytes is not None
+                    and content_length > self._read_max_bytes
+                ):
+                    raise ConnectError(
+                        Code.RESOURCE_EXHAUSTED,
+                        f"message is larger than configured max {self._read_max_bytes}",
+                    )
                 req_body = _read_body_with_content_length(environ, content_length)
             else:
-                req_body = b"".join(_read_body(environ))
+                chunks: list[bytes] = []
+                read_bytes = 0
+                for chunk in _read_body(environ):
+                    read_bytes += len(chunk)
+                    if (
+                        self._read_max_bytes is not None
+                        and read_bytes > self._read_max_bytes
+                    ):
+                        raise ConnectError(
+                            Code.RESOURCE_EXHAUSTED,
+                            f"message is larger than configured max {self._read_max_bytes}",
+                        )
+                    chunks.append(chunk)
+                req_body = b"".join(chunks)
 
             # Handle compression if specified
             compression_name = environ.get("HTTP_CONTENT_ENCODING", "identity").lower()

--- a/src/connectrpc/server.py
+++ b/src/connectrpc/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 __all__ = [
+    "DEFAULT_READ_MAX_BYTES",
     "ConnectASGIApplication",
     "ConnectWSGIApplication",
     "Endpoint",
@@ -11,5 +12,5 @@ __all__ = [
 
 
 from ._server_async import ConnectASGIApplication
-from ._server_shared import Endpoint, EndpointSync
+from ._server_shared import DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from ._server_sync import ConnectWSGIApplication

--- a/test/connectrpc/example/haberdasher_connect.py
+++ b/test/connectrpc/example/haberdasher_connect.py
@@ -12,7 +12,7 @@ from connectrpc.client import ConnectClient, ConnectClientSync
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from connectrpc.method import IdempotencyLevel, MethodInfo
-from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
+from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from protobuf import DescService
 from protobuf.wkt import Empty
 
@@ -76,7 +76,7 @@ class HaberdasherASGIApplication(ConnectASGIApplication[Haberdasher]):
         service: Haberdasher | AsyncGenerator[Haberdasher],
         *,
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:
@@ -344,7 +344,7 @@ class HaberdasherWSGIApplication(ConnectWSGIApplication):
         self,
         service: HaberdasherSync,
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = None,
     ) -> None:

--- a/test/google_compat/connectrpc/example/haberdasher_connect.py
+++ b/test/google_compat/connectrpc/example/haberdasher_connect.py
@@ -15,7 +15,7 @@ from connectrpc.compression.gzip import GzipCompression
 from connectrpc.errors import ConnectError
 from connectrpc.method import IdempotencyLevel, MethodInfo
 from connectrpc.protocol import ProtocolType
-from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
+from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, DEFAULT_READ_MAX_BYTES, Endpoint, EndpointSync
 from google.protobuf.empty_pb2 import Empty
 from pyqwest import Client, SyncClient
 
@@ -79,7 +79,7 @@ class HaberdasherASGIApplication(ConnectASGIApplication[Haberdasher]):
         service: Haberdasher | AsyncGenerator[Haberdasher],
         *,
         interceptors: Iterable[Interceptor] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = _DEFAULT_CODECS,
     ) -> None:
@@ -367,7 +367,7 @@ class HaberdasherWSGIApplication(ConnectWSGIApplication):
         self,
         service: HaberdasherSync,
         interceptors: Iterable[InterceptorSync] = (),
-        read_max_bytes: int | None = None,
+        read_max_bytes: int | None = DEFAULT_READ_MAX_BYTES,
         compressions: Iterable[Compression] | None = None,
         codecs: Iterable[Codec] | None = _DEFAULT_CODECS,
     ) -> None:

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import random
 import struct
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,7 @@ from pyqwest.testing import ASGITransport, WSGITransport
 from connectrpc.code import Code
 from connectrpc.codec import proto_binary_codec, proto_json_codec
 from connectrpc.errors import ConnectError
+from connectrpc.server import DEFAULT_READ_MAX_BYTES
 
 from ._util import resolve_compression
 from .connectrpc.example.haberdasher_connect import (
@@ -289,16 +291,26 @@ async def test_roundtrip_response_stream_async(
     assert exc_info.value.message == "No more hats available"
 
 
+def _payload(compressible: bool) -> str:
+    if compressible:
+        return "X" * 1000
+    rng = random.Random(42)  # noqa: S311 # deterministic incompressible data
+    return "".join(chr(rng.randint(0x20, 0x7E)) for _ in range(1000))
+
+
+@pytest.mark.parametrize("compressible", [False, True])
 @pytest.mark.parametrize("client_bad", [False, True])
 @pytest.mark.parametrize("compression_name", ["gzip", "br", "zstd", "identity"])
-def test_message_limit_sync(client_bad: bool, compression_name: str) -> None:
+def test_message_limit_sync(
+    client_bad: bool, compression_name: str, compressible: bool
+) -> None:
     requests: list[Size] = []
     responses: list[Hat] = []
 
     good_size = Size(description="good")
-    bad_size = Size(description="X" * 1000)
+    bad_size = Size(description=_payload(compressible))
     good_hat = Hat(color="good")
-    bad_hat = Hat(color="X" * 1000)
+    bad_hat = Hat(color=_payload(compressible))
 
     class LargeHaberdasher(HaberdasherSync):
         def make_hat(self, request, _ctx):
@@ -354,17 +366,20 @@ def test_message_limit_sync(client_bad: bool, compression_name: str) -> None:
             assert len(responses) == 1
 
 
+@pytest.mark.parametrize("compressible", [False, True])
 @pytest.mark.parametrize("client_bad", [False, True])
 @pytest.mark.parametrize("compression_name", ["gzip", "br", "zstd", "identity"])
 @pytest.mark.asyncio
-async def test_message_limit_async(client_bad: bool, compression_name: str) -> None:
+async def test_message_limit_async(
+    client_bad: bool, compression_name: str, compressible: bool
+) -> None:
     requests: list[Size] = []
     responses: list[Hat] = []
 
     good_size = Size(description="good")
-    bad_size = Size(description="X" * 1000)
+    bad_size = Size(description=_payload(compressible))
     good_hat = Hat(color="good")
-    bad_hat = Hat(color="X" * 1000)
+    bad_hat = Hat(color=_payload(compressible))
 
     class LargeHaberdasher(Haberdasher):
         async def make_hat(self, request, _ctx):
@@ -420,6 +435,71 @@ async def test_message_limit_async(client_bad: bool, compression_name: str) -> N
         else:
             assert len(requests) == 2
             assert len(responses) == 1
+
+
+# The size of a description that results in exactly 4MB+1 on the wire.
+_BIG_DESCRIPTION_LENGTH = DEFAULT_READ_MAX_BYTES + 1 - 5
+
+
+@pytest.mark.parametrize("unlimited", [False, True])
+def test_message_limit_default_sync(unlimited: bool) -> None:
+    class EchoSizeHaberdasher(HaberdasherSync):
+        def make_hat(self, request, _ctx):
+            return Hat(size=len(request.description))
+
+    big_size = Size(description="X" * _BIG_DESCRIPTION_LENGTH)
+    assert len(big_size.to_binary()) == DEFAULT_READ_MAX_BYTES + 1
+    # We specifically want to test not setting vs setting to None
+    app = (
+        HaberdasherWSGIApplication(EchoSizeHaberdasher(), read_max_bytes=None)
+        if unlimited
+        else HaberdasherWSGIApplication(EchoSizeHaberdasher())
+    )
+    with HaberdasherClientSync(
+        "http://localhost", http_client=SyncClient(WSGITransport(app))
+    ) as client:
+        if unlimited:
+            response = client.make_hat(request=big_size)
+            assert response.size == _BIG_DESCRIPTION_LENGTH
+        else:
+            with pytest.raises(ConnectError) as exc_info:
+                client.make_hat(request=big_size)
+            assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
+            assert (
+                exc_info.value.message
+                == f"message is larger than configured max {DEFAULT_READ_MAX_BYTES}"
+            )
+
+
+@pytest.mark.parametrize("unlimited", [False, True])
+@pytest.mark.asyncio
+async def test_message_limit_default_async(unlimited: bool) -> None:
+    class EchoSizeHaberdasher(Haberdasher):
+        async def make_hat(self, request, _ctx):
+            return Hat(size=len(request.description))
+
+    big_size = Size(description="X" * _BIG_DESCRIPTION_LENGTH)
+    assert len(big_size.to_binary()) == DEFAULT_READ_MAX_BYTES + 1
+    # We specifically want to test not setting vs setting to None
+    app = (
+        HaberdasherASGIApplication(EchoSizeHaberdasher(), read_max_bytes=None)
+        if unlimited
+        else HaberdasherASGIApplication(EchoSizeHaberdasher())
+    )
+    async with HaberdasherClient(
+        "http://localhost", http_client=Client(transport=ASGITransport(app))
+    ) as client:
+        if unlimited:
+            response = await client.make_hat(request=big_size)
+            assert response.size == _BIG_DESCRIPTION_LENGTH
+        else:
+            with pytest.raises(ConnectError) as exc_info:
+                await client.make_hat(request=big_size)
+            assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
+            assert (
+                exc_info.value.message
+                == f"message is larger than configured max {DEFAULT_READ_MAX_BYTES}"
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Connect is [moving](https://github.com/connectrpc/connect-go/pull/965) to apply a default read limit of 4MB, matching gRPC. Since we are pre-v1, we can change the default now.

This also goes ahead and makes the check more robust by checking both before and after applying compression since otherwise a bad request can still take as much memory as it wants during the initial read. This is an important improvement independent of the default value change.