### PR TITLE
Apply message read limit during decompression

### DIFF
--- a/src/connectrpc/_compression.py
+++ b/src/connectrpc/_compression.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from connectrpc.compression.gzip import GzipCompression
 
+from ._shared import message_too_large_error
 from .compression import Compression
 
 if TYPE_CHECKING:
@@ -18,8 +19,12 @@ class IdentityCompression(Compression):
         """Return data as-is without compression."""
         return data if isinstance(data, bytes) else bytes(data)
 
-    def decompress(self, data: bytes | bytearray | memoryview) -> bytes:
+    def decompress(
+        self, data: bytes | bytearray | memoryview, read_max_bytes: int | None = None
+    ) -> bytes:
         """Return data as-is without decompression."""
+        if read_max_bytes is not None and len(data) > read_max_bytes:
+            raise message_too_large_error(read_max_bytes)
         return data if isinstance(data, bytes) else bytes(data)
 
 

--- a/src/connectrpc/_envelope.py
+++ b/src/connectrpc/_envelope.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from ._compression import Compression, IdentityCompression
+from ._shared import message_too_large_error
 from .code import Code
 from .errors import ConnectError
 
@@ -61,15 +62,9 @@ class EnvelopeReader(Generic[_RES]):
                             Code.INTERNAL,
                             "protocol error: sent compressed message without compression support",
                         )
-                    message_data = self._compression.decompress(message_data)
 
-                if (
-                    self._read_max_bytes is not None
-                    and len(message_data) > self._read_max_bytes
-                ):
-                    raise ConnectError(
-                        Code.RESOURCE_EXHAUSTED,
-                        f"message is larger than configured max {self._read_max_bytes}",
+                    message_data = self._compression.decompress(
+                        message_data, self._read_max_bytes
                     )
 
                 if self.handle_end_message(prefix_byte, message_data):
@@ -86,10 +81,7 @@ class EnvelopeReader(Generic[_RES]):
                 self._read_max_bytes is not None
                 and self._next_message_length > self._read_max_bytes
             ):
-                raise ConnectError(
-                    Code.RESOURCE_EXHAUSTED,
-                    f"message is larger than configured max {self._read_max_bytes}",
-                )
+                raise message_too_large_error(self._read_max_bytes)
 
     def handle_end_message(
         self, _prefix_byte: int, _message_data: bytes | bytearray, /

--- a/src/connectrpc/_server_async.py
+++ b/src/connectrpc/_server_async.py
@@ -329,7 +329,7 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
 
         # Decompress and decode message
         if message:  # Don't decompress empty messages
-            message = compression.decompress(message)
+            message = compression.decompress(message, self._read_max_bytes)
 
         # Get the appropriate decoder for the endpoint
         return codec.decode(message, endpoint.method.input)
@@ -365,13 +365,7 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
             )
 
         if req_body:  # Don't decompress empty body
-            req_body = compression.decompress(req_body)
-
-        if self._read_max_bytes is not None and len(req_body) > self._read_max_bytes:
-            raise ConnectError(
-                Code.RESOURCE_EXHAUSTED,
-                f"message is larger than configured max {self._read_max_bytes}",
-            )
+            req_body = compression.decompress(req_body, self._read_max_bytes)
 
         return codec.decode(req_body, endpoint.method.input)
 

--- a/src/connectrpc/_server_sync.py
+++ b/src/connectrpc/_server_sync.py
@@ -334,29 +334,20 @@ class ConnectWSGIApplication(ABC):
 
             # Handle compression if specified
             compression_name = environ.get("HTTP_CONTENT_ENCODING", "identity").lower()
-            if compression_name != "identity":
-                compression = self._compressions.get(compression_name)
-                if not compression:
-                    raise ConnectError(
-                        Code.UNIMPLEMENTED,
-                        f"unknown compression: '{compression_name}': supported encodings are {', '.join(self._compressions.keys())}",
-                    )
-                try:
-                    req_body = compression.decompress(req_body)
-                except Exception as e:
-                    raise ConnectError(
-                        Code.INVALID_ARGUMENT,
-                        f"Failed to decompress request body: {e!s}",
-                    ) from e
-
-            if (
-                self._read_max_bytes is not None
-                and len(req_body) > self._read_max_bytes
-            ):
+            compression = self._compressions.get(compression_name)
+            if not compression:
                 raise ConnectError(
-                    Code.RESOURCE_EXHAUSTED,
-                    f"message is larger than configured max {self._read_max_bytes}",
+                    Code.UNIMPLEMENTED,
+                    f"unknown compression: '{compression_name}': supported encodings are {', '.join(self._compressions.keys())}",
                 )
+            try:
+                req_body = compression.decompress(req_body, self._read_max_bytes)
+            except ConnectError:
+                raise
+            except Exception as e:
+                raise ConnectError(
+                    Code.INVALID_ARGUMENT, f"Failed to decompress request body: {e!s}"
+                ) from e
 
             try:
                 return codec.decode(req_body, endpoint.method.input), codec
@@ -402,13 +393,15 @@ class ConnectWSGIApplication(ABC):
             # Handle compression if specified
             if "compression" in params:
                 compression_name = params["compression"][0]
-                compression = self._compressions.get(compression_name)
-                if not compression:
-                    raise ConnectError(
-                        Code.UNIMPLEMENTED,
-                        f"unknown compression: '{compression_name}': supported encodings are {', '.join(self._compressions.keys())}",
-                    )
-                message = compression.decompress(message)
+            else:
+                compression_name = "identity"
+            compression = self._compressions.get(compression_name)
+            if not compression:
+                raise ConnectError(
+                    Code.UNIMPLEMENTED,
+                    f"unknown compression: '{compression_name}': supported encodings are {', '.join(self._compressions.keys())}",
+                )
+            message = compression.decompress(message, self._read_max_bytes)
 
             codec_name = params.get("encoding", ("",))[0]
             codec = self._codecs.get(codec_name)

--- a/src/connectrpc/_shared.py
+++ b/src/connectrpc/_shared.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .code import Code
+from .errors import ConnectError
+
+
+def message_too_large_error(read_max_bytes: int) -> ConnectError:
+    msg = f"message is larger than configured max {read_max_bytes}"
+    return ConnectError(Code.RESOURCE_EXHAUSTED, msg)

--- a/src/connectrpc/compression/__init__.py
+++ b/src/connectrpc/compression/__init__.py
@@ -33,6 +33,20 @@ class Compression(Protocol):
         """Compress the given data."""
         ...
 
-    def decompress(self, data: bytes | bytearray | memoryview) -> bytes:
-        """Decompress the given data."""
+    def decompress(
+        self, data: bytes | bytearray | memoryview, read_max_bytes: int | None = None
+    ) -> bytes:
+        """Decompress the given data.
+
+        Args:
+            data: The data to decompress.
+            read_max_bytes: The limit on the number of uncompressed bytes.
+
+        Raises:
+            ConnectError: (RESOURCE_EXHAUSTED) If the decompressed data exceeds the limit.
+
+        Returns:
+            The decompressed data.
+
+        """
         ...

--- a/src/connectrpc/compression/brotli.py
+++ b/src/connectrpc/compression/brotli.py
@@ -6,6 +6,8 @@ __all__ = ["BrotliCompression"]
 
 import brotli
 
+from connectrpc._shared import message_too_large_error
+
 from . import Compression
 
 
@@ -29,6 +31,29 @@ class BrotliCompression(Compression):
         """Compress the given data using Brotli."""
         return brotli.compress(data, quality=self._quality)
 
-    def decompress(self, data: bytes | bytearray | memoryview) -> bytes:
+    def decompress(
+        self, data: bytes | bytearray | memoryview, read_max_bytes: int | None = None
+    ) -> bytes:
         """Decompress the given data using Brotli."""
-        return brotli.decompress(data)
+        if read_max_bytes is None:
+            return brotli.decompress(data)
+        decompressor = brotli.Decompressor()
+        parts: list[bytes] = []
+        total = 0
+        out = decompressor.process(data, output_buffer_limit=read_max_bytes + 1)
+        while True:
+            total += len(out)
+            parts.append(out)
+            if total > read_max_bytes:
+                raise message_too_large_error(read_max_bytes)
+            if decompressor.is_finished():
+                return b"".join(parts)
+            if decompressor.can_accept_more_data():
+                msg = "compressed stream ended before the end-of-stream marker was reached"
+                raise brotli.error(msg)
+            out = decompressor.process(
+                b"", output_buffer_limit=read_max_bytes + 1 - total
+            )
+            if not out:
+                msg = "decompressor made no progress"
+                raise brotli.error(msg)

--- a/src/connectrpc/compression/gzip.py
+++ b/src/connectrpc/compression/gzip.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import gzip
+import zlib
+
+from connectrpc._shared import message_too_large_error
 
 from . import Compression
 
@@ -27,6 +30,37 @@ class GzipCompression(Compression):
         """Compress the given data using Gzip."""
         return gzip.compress(data, compresslevel=self._level)
 
-    def decompress(self, data: bytes | bytearray | memoryview) -> bytes:
+    def decompress(
+        self, data: bytes | bytearray | memoryview, read_max_bytes: int | None = None
+    ) -> bytes:
         """Decompress the given data using Gzip."""
-        return gzip.decompress(data)
+        if read_max_bytes is None:
+            return gzip.decompress(data)
+        if not data:
+            return b""
+        parts: list[bytes] = []
+        total = 0
+        decompressor = zlib.decompressobj(wbits=31)
+        remaining_input: bytes | bytearray | memoryview = data
+        while True:
+            out = decompressor.decompress(remaining_input, read_max_bytes + 1 - total)
+            total += len(out)
+            parts.append(out)
+            if total > read_max_bytes:
+                raise message_too_large_error(read_max_bytes)
+            if decompressor.eof:
+                # In practice should never happen but match gzip.decompress above by
+                # handling multi-member payloads.
+                remaining_input = decompressor.unused_data
+                if not remaining_input:
+                    return b"".join(parts)
+                decompressor = zlib.decompressobj(wbits=31)
+            else:
+                tail = decompressor.unconsumed_tail
+                if not tail:
+                    msg = "Compressed file ended before the end-of-stream marker was reached"
+                    raise EOFError(msg)
+                if not out and len(tail) == len(remaining_input):
+                    msg = "decompressor made no progress"
+                    raise zlib.error(msg)
+                remaining_input = tail

--- a/src/connectrpc/compression/zstd.py
+++ b/src/connectrpc/compression/zstd.py
@@ -6,6 +6,8 @@ __all__ = ["ZstdCompression"]
 
 import zstandard
 
+from connectrpc._shared import message_too_large_error
+
 from . import Compression
 
 
@@ -29,9 +31,21 @@ class ZstdCompression(Compression):
         """Compress the given data using Zstandard."""
         return zstandard.ZstdCompressor(level=self._level).compress(data)
 
-    def decompress(self, data: bytes | bytearray | memoryview) -> bytes:
+    def decompress(
+        self, data: bytes | bytearray | memoryview, read_max_bytes: int | None = None
+    ) -> bytes:
         """Decompress the given data using Zstandard."""
         # Support clients sending frames without length by using
         # stream API.
         with zstandard.ZstdDecompressor().stream_reader(data) as reader:
-            return reader.read()
+            if read_max_bytes is None:
+                return reader.read()
+            parts: list[bytes] = []
+            remaining = read_max_bytes + 1
+            while remaining > 0:
+                out = reader.read(remaining)
+                if not out:
+                    return b"".join(parts)
+                parts.append(out)
+                remaining -= len(out)
+            raise message_too_large_error(read_max_bytes)

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import brotli as brotli_lib
 import pytest
 from pyqwest import Client, SyncClient
 from pyqwest.testing import ASGITransport, WSGITransport
 
 from connectrpc._compression import IdentityCompression
 from connectrpc.client import ResponseMetadata
+from connectrpc.code import Code
 from connectrpc.compression.brotli import BrotliCompression
 from connectrpc.compression.gzip import GzipCompression
 from connectrpc.compression.zstd import ZstdCompression
+from connectrpc.errors import ConnectError
 
 from ._util import resolve_compression
 from .connectrpc.example.haberdasher_connect import (
@@ -20,6 +25,9 @@ from .connectrpc.example.haberdasher_connect import (
     HaberdasherWSGIApplication,
 )
 from .connectrpc.example.haberdasher_pb import Hat, Size
+
+if TYPE_CHECKING:
+    from connectrpc.compression import Compression
 
 
 @pytest.mark.asyncio
@@ -113,3 +121,103 @@ class TestIdentityCompression:
         decompressed = compression.decompress(compressed)
         assert decompressed == b"hello"
         assert isinstance(decompressed, bytes)
+
+    def test_read_max_bytes_exceeded(self) -> None:
+        with pytest.raises(ConnectError) as exc_info:
+            IdentityCompression().decompress(b"hello", 4)
+        assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
+
+
+_READ_MAX_BYTES = 100
+
+
+@pytest.mark.parametrize(
+    "compression",
+    [GzipCompression(), ZstdCompression(), BrotliCompression()],
+    ids=["gzip", "zstd", "br"],
+)
+class TestDecompressReadMaxBytes:
+    def test_at_limit(self, compression: Compression) -> None:
+        data = b"a" * _READ_MAX_BYTES
+        compressed = compression.compress(data)
+        assert compression.decompress(compressed, _READ_MAX_BYTES) == data
+
+    def test_over_limit(self, compression: Compression) -> None:
+        data = b"a" * (_READ_MAX_BYTES + 1)
+        compressed = compression.compress(data)
+        with pytest.raises(ConnectError) as exc_info:
+            compression.decompress(compressed, _READ_MAX_BYTES)
+        assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
+        assert (
+            exc_info.value.message
+            == f"message is larger than configured max {_READ_MAX_BYTES}"
+        )
+
+    def test_over_limit_incompressible(self, compression: Compression) -> None:
+        data = bytes(range(256)) * ((_READ_MAX_BYTES // 256) + 2)
+        compressed = compression.compress(data)
+        with pytest.raises(ConnectError) as exc_info:
+            compression.decompress(compressed, _READ_MAX_BYTES)
+        assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
+
+    def test_decompression_bomb(self, compression: Compression) -> None:
+        data = bytes(64 * 1024 * 1024)
+        compressed = compression.compress(data)
+        with pytest.raises(ConnectError) as exc_info:
+            compression.decompress(compressed, _READ_MAX_BYTES)
+        assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
+
+    def test_no_limit(self, compression: Compression) -> None:
+        data = b"a" * (_READ_MAX_BYTES + 1)
+        compressed = compression.compress(data)
+        assert compression.decompress(compressed) == data
+
+    @pytest.mark.parametrize("ctor", [bytearray, memoryview])
+    def test_not_bytes(
+        self, compression: Compression, ctor: type[bytearray | memoryview]
+    ) -> None:
+        data = b"a" * _READ_MAX_BYTES
+        compressed = ctor(compression.compress(data))
+        assert compression.decompress(compressed, _READ_MAX_BYTES) == data
+
+
+class TestGzipDecompress:
+    def test_empty_with_limit(self) -> None:
+        assert GzipCompression().decompress(b"", _READ_MAX_BYTES) == b""
+
+    def test_multi_member_with_limit(self) -> None:
+        compression = GzipCompression()
+        compressed = compression.compress(b"a" * 60) + compression.compress(b"b" * 60)
+        assert compression.decompress(compressed, 120) == b"a" * 60 + b"b" * 60
+
+    def test_multi_member_over_limit(self) -> None:
+        compression = GzipCompression()
+        compressed = compression.compress(b"a" * 60) + compression.compress(b"b" * 60)
+        with pytest.raises(ConnectError) as exc_info:
+            compression.decompress(compressed, _READ_MAX_BYTES)
+        assert exc_info.value.code == Code.RESOURCE_EXHAUSTED
+
+    def test_truncated_with_limit(self) -> None:
+        compression = GzipCompression()
+        compressed = compression.compress(b"a" * 60)
+        with pytest.raises(EOFError):
+            compression.decompress(compressed[:-5], _READ_MAX_BYTES)
+
+
+class TestZstdDecompress:
+    def test_empty_with_limit(self) -> None:
+        assert ZstdCompression().decompress(b"", _READ_MAX_BYTES) == b""
+
+
+class TestBrotliDecompress:
+    def test_truncated_with_limit(self) -> None:
+        compression = BrotliCompression()
+        compressed = compression.compress(b"a" * 60)
+        with pytest.raises(brotli_lib.error):
+            compression.decompress(compressed[: len(compressed) // 2], _READ_MAX_BYTES)
+
+    def test_trailing_garbage_with_limit(self) -> None:
+        compression = BrotliCompression()
+        compressed = compression.compress(b"a" * 60)
+        with pytest.raises(brotli_lib.error):
+            compression.decompress(compressed + b"garbage", _READ_MAX_BYTES)


### PR DESCRIPTION
This was always a known limitation but had skipped improving it given how tedious it is in Python to implement limit during decompression. But of course now is the right time to finally resolve it since it is an important safety mechanism.