### PR TITLE
Execute metadata interceptors at the start of the chain before parsing request

### DIFF
--- a/src/connectrpc/_interceptor_async.py
+++ b/src/connectrpc/_interceptor_async.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Sequence
@@ -135,6 +135,12 @@ class MetadataInterceptor(Protocol[T]):
     Only metadata such as headers and trailers is accessible. To access request
     and response bodies of a method, instead use an interceptor corresponding to
     the type of method such as [UnaryInterceptor][].
+
+    On servers, metadata interceptors at the front of the interceptor list are
+    invoked before the request message is read or parsed, allowing logic such
+    as authentication to reject a request without processing its body. A
+    metadata interceptor following a message interceptor is invoked in order
+    within the chain, after the request message is parsed.
     """
 
     async def on_start(self, ctx: RequestContext) -> T:
@@ -238,6 +244,75 @@ class MetadataInterceptorInvoker(Generic[T]):
             raise
         finally:
             await self._delegate.on_end(token, ctx, error)
+
+
+class MetadataInterceptorsRun:
+    """A single request's invocation of hoisted metadata interceptors.
+
+    Metadata interceptors at the front of the interceptor list don't have
+    access to the request message, so servers invoke them before reading or
+    parsing the request instead of wrapping the endpoint function.
+    """
+
+    _interceptors: Sequence[MetadataInterceptor[Any]]
+    _ctx: RequestContext
+    _started: list[tuple[MetadataInterceptor[Any], Any]]
+    _ended: bool
+
+    def __init__(
+        self, interceptors: Sequence[MetadataInterceptor[Any]], ctx: RequestContext
+    ) -> None:
+        self._interceptors = interceptors
+        self._ctx = ctx
+        self._started = []
+        self._ended = False
+
+    async def start(self) -> None:
+        """Invoke on_start for each interceptor in order.
+
+        If an on_start raises, interceptors that already started are ended by
+        the following call to [end][].
+        """
+        for interceptor in self._interceptors:
+            token = await interceptor.on_start(self._ctx)
+            self._started.append((interceptor, token))
+
+    async def end(self, error: Exception | None) -> Exception | None:
+        """Invoke on_end for each started interceptor in reverse order.
+
+        If an on_end raises, the exception replaces the current error and is
+        passed to the remaining interceptors, matching the behavior of
+        interceptors nested around the endpoint function. Only the first call
+        invokes on_end; later calls return the error unchanged.
+        """
+        if self._ended:
+            return error
+        self._ended = True
+        for interceptor, token in reversed(self._started):
+            try:
+                await interceptor.on_end(token, self._ctx, error)
+            except Exception as e:  # noqa: BLE001, PERF203 # invoking user callback
+                error = e
+        return error
+
+
+def split_leading_metadata_interceptors(
+    interceptors: Iterable[Interceptor],
+) -> tuple[Sequence[MetadataInterceptor[Any]], Sequence[Interceptor]]:
+    """Split interceptors into leading metadata interceptors and the rest.
+
+    Metadata interceptors at the front of the list can be invoked before the
+    request message is read since they don't have access to it. A metadata
+    interceptor following a message interceptor must still be invoked in order
+    within the chain.
+    """
+    remaining = list(interceptors)
+    leading: list[MetadataInterceptor[Any]] = []
+    for i, interceptor in enumerate(remaining):
+        if not isinstance(interceptor, MetadataInterceptor):
+            return leading, remaining[i:]
+        leading.append(interceptor)
+    return leading, []
 
 
 def resolve_interceptors(

--- a/src/connectrpc/_interceptor_sync.py
+++ b/src/connectrpc/_interceptor_sync.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, Protocol, TypeVar, runtime_checkable
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, runtime_checkable
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -135,6 +135,12 @@ class MetadataInterceptorSync(Protocol[T]):
     Only metadata such as headers and trailers is accessible. To access request
     and response bodies of a method, instead use an interceptor corresponding to
     the type of method such as [UnaryInterceptorSync][].
+
+    On servers, metadata interceptors at the front of the interceptor list are
+    invoked before the request message is read or parsed, allowing logic such
+    as authentication to reject a request without processing its body. A
+    metadata interceptor following a message interceptor is invoked in order
+    within the chain, after the request message is parsed.
     """
 
     def on_start_sync(self, ctx: RequestContext, /) -> T:
@@ -237,6 +243,75 @@ class MetadataInterceptorInvokerSync(Generic[T]):
             raise
         finally:
             self._delegate.on_end_sync(token, ctx, error)
+
+
+class MetadataInterceptorsRunSync:
+    """A single request's invocation of hoisted metadata interceptors.
+
+    Metadata interceptors at the front of the interceptor list don't have
+    access to the request message, so servers invoke them before reading or
+    parsing the request instead of wrapping the endpoint function.
+    """
+
+    _interceptors: Sequence[MetadataInterceptorSync[Any]]
+    _ctx: RequestContext
+    _started: list[tuple[MetadataInterceptorSync[Any], Any]]
+    _ended: bool
+
+    def __init__(
+        self, interceptors: Sequence[MetadataInterceptorSync[Any]], ctx: RequestContext
+    ) -> None:
+        self._interceptors = interceptors
+        self._ctx = ctx
+        self._started = []
+        self._ended = False
+
+    def start(self) -> None:
+        """Invoke on_start_sync for each interceptor in order.
+
+        If an on_start_sync raises, interceptors that already started are ended
+        by the following call to [end][].
+        """
+        for interceptor in self._interceptors:
+            token = interceptor.on_start_sync(self._ctx)
+            self._started.append((interceptor, token))
+
+    def end(self, error: Exception | None) -> Exception | None:
+        """Invoke on_end_sync for each started interceptor in reverse order.
+
+        If an on_end_sync raises, the exception replaces the current error and
+        is passed to the remaining interceptors, matching the behavior of
+        interceptors nested around the endpoint function. Only the first call
+        invokes on_end_sync; later calls return the error unchanged.
+        """
+        if self._ended:
+            return error
+        self._ended = True
+        for interceptor, token in reversed(self._started):
+            try:
+                interceptor.on_end_sync(token, self._ctx, error)
+            except Exception as e:  # noqa: BLE001, PERF203 # invoking user callback
+                error = e
+        return error
+
+
+def split_leading_metadata_interceptors(
+    interceptors: Iterable[InterceptorSync],
+) -> tuple[Sequence[MetadataInterceptorSync[Any]], Sequence[InterceptorSync]]:
+    """Split interceptors into leading metadata interceptors and the rest.
+
+    Metadata interceptors at the front of the list can be invoked before the
+    request message is read since they don't have access to it. A metadata
+    interceptor following a message interceptor must still be invoked in order
+    within the chain.
+    """
+    remaining = list(interceptors)
+    leading: list[MetadataInterceptorSync[Any]] = []
+    for i, interceptor in enumerate(remaining):
+        if not isinstance(interceptor, MetadataInterceptorSync):
+            return leading, remaining[i:]
+        leading.append(interceptor)
+    return leading, []
 
 
 def resolve_interceptors(

--- a/src/connectrpc/_server_async.py
+++ b/src/connectrpc/_server_async.py
@@ -18,9 +18,11 @@ from ._interceptor_async import (
     BidiStreamInterceptor,
     ClientStreamInterceptor,
     Interceptor,
+    MetadataInterceptorsRun,
     ServerStreamInterceptor,
     UnaryInterceptor,
     resolve_interceptors,
+    split_leading_metadata_interceptors,
 )
 from ._protocol import ConnectWireError, HTTPError, ServerProtocol
 from ._protocol_connect import CONNECT_UNARY_CONTENT_TYPE_PREFIX, ConnectServerProtocol
@@ -112,7 +114,9 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
         super().__init__()
         self._service = service
         self._endpoints = endpoints
-        self._interceptors = interceptors
+        self._metadata_interceptors, self._interceptors = (
+            split_leading_metadata_interceptors(interceptors)
+        )
         self._resolved_endpoints = None
         self._read_max_bytes = read_max_bytes
         self._compressions = resolve_compressions(compressions)
@@ -258,12 +262,27 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
         accept_encoding = headers.get("accept-encoding", "")
         compression = negotiate_compression(accept_encoding, self._compressions)
 
-        if http_method == "GET":
-            request = await self._read_get_request(endpoint, codec, query_params)
-        else:
-            request = await self._read_post_request(endpoint, receive, codec, headers)
-
-        response_data = await endpoint.function(request, ctx)
+        metadata_run = MetadataInterceptorsRun(self._metadata_interceptors, ctx)
+        response_data: _RES | None = None
+        error: Exception | None = None
+        try:
+            await metadata_run.start()
+            if http_method == "GET":
+                request = await self._read_get_request(endpoint, codec, query_params)
+            else:
+                request = await self._read_post_request(
+                    endpoint, receive, codec, headers
+                )
+            response_data = await endpoint.function(request, ctx)
+        except Exception as e:  # noqa: BLE001 # re-raised after ending the run
+            error = e
+        finally:
+            # End the run before sending the response so on_end can still modify
+            # response metadata.
+            error = await metadata_run.end(error)
+        if error is not None:
+            raise error
+        assert response_data is not None  # noqa: S101 # no error means function returned
 
         res_bytes = codec.encode(response_data)
         response_headers: list[tuple[bytes, bytes]] = [
@@ -391,9 +410,11 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
 
         writer = protocol.create_envelope_writer(codec, resp_compression)
 
+        metadata_run = MetadataInterceptorsRun(self._metadata_interceptors, ctx)
         error: Exception | None = None
         sent_headers = False
         try:
+            await metadata_run.start()
             if not req_compression:
                 raise ConnectError(
                     Code.UNIMPLEMENTED, "Unrecognized request compression"
@@ -413,9 +434,15 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
                 case EndpointUnary():
                     request = await _consume_single_request(request_stream)
                     response = await endpoint.function(request, ctx)
+                    # End the run before sending the response so on_end can still
+                    # modify response metadata.
+                    if (end_error := await metadata_run.end(None)) is not None:
+                        raise end_error
                     response_stream = _yield_single_response(response)
                 case EndpointClientStream():
                     response = await endpoint.function(request_stream, ctx)
+                    if (end_error := await metadata_run.end(None)) is not None:
+                        raise end_error
                     response_stream = _yield_single_response(response)
                 case EndpointServerStream():
                     request = await _consume_single_request(request_stream)
@@ -469,6 +496,9 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
         except Exception as e:  # noqa: BLE001 # invoking user callback
             error = e
         finally:
+            # End the run before ending the response so on_end can still modify
+            # response trailers. This is a no-op if the run already ended.
+            error = await metadata_run.end(error)
             end_message = writer.end(
                 ctx.response_trailers,
                 ConnectWireError.from_exception(error) if error else None,

--- a/src/connectrpc/_server_sync.py
+++ b/src/connectrpc/_server_sync.py
@@ -18,9 +18,11 @@ from ._interceptor_sync import (
     ClientStreamInterceptorSync,
     InterceptorSync,
     MetadataInterceptorInvokerSync,
+    MetadataInterceptorsRunSync,
     MetadataInterceptorSync,
     ServerStreamInterceptorSync,
     UnaryInterceptorSync,
+    split_leading_metadata_interceptors,
 )
 from ._protocol import ConnectWireError, HTTPError, ServerProtocol
 from ._protocol_connect import (
@@ -175,6 +177,9 @@ class ConnectWSGIApplication(ABC):
 
         """
         super().__init__()
+        self._metadata_interceptors, interceptors = split_leading_metadata_interceptors(
+            interceptors
+        )
         if interceptors:
             interceptors = [
                 MetadataInterceptorInvokerSync(interceptor)
@@ -255,14 +260,30 @@ class ConnectWSGIApplication(ABC):
         ctx: RequestContext[_REQ, _RES],
         headers: Headers,
     ) -> Iterable[bytes]:
-        # Handle request based on method
-        if http_method == "GET":
-            request, codec = self._handle_get_request(environ, endpoint)
-        else:
-            request, codec = self._handle_post_request(environ, endpoint, headers)
+        metadata_run = MetadataInterceptorsRunSync(self._metadata_interceptors, ctx)
+        response: _RES | None = None
+        codec: Codec | None = None
+        error: Exception | None = None
+        try:
+            metadata_run.start()
+            # Handle request based on method
+            if http_method == "GET":
+                request, codec = self._handle_get_request(environ, endpoint)
+            else:
+                request, codec = self._handle_post_request(environ, endpoint, headers)
 
-        # Process request
-        response = endpoint.function(request, ctx)
+            # Process request
+            response = endpoint.function(request, ctx)
+        except Exception as e:  # noqa: BLE001 # re-raised after ending the run
+            error = e
+        finally:
+            # End the run before sending the response so on_end can still modify
+            # response metadata.
+            error = metadata_run.end(error)
+        if error is not None:
+            raise error
+        assert response is not None  # noqa: S101 # no error means function returned
+        assert codec is not None  # noqa: S101 # no error means request was parsed
 
         # Encode response
         res_bytes = codec.encode(response)
@@ -461,7 +482,9 @@ class ConnectWSGIApplication(ABC):
                 ],
             )
         writer = protocol.create_envelope_writer(codec, resp_compression)
+        metadata_run = MetadataInterceptorsRunSync(self._metadata_interceptors, ctx)
         try:
+            metadata_run.start()
             if not req_compression:
                 raise ConnectError(
                     Code.UNIMPLEMENTED, "Unrecognized request compression"
@@ -477,9 +500,15 @@ class ConnectWSGIApplication(ABC):
                 case _server_shared.EndpointUnarySync():
                     request = _consume_single_request(request_stream)
                     response = endpoint.function(request, ctx)
+                    # End the run before sending the response so on_end can still
+                    # modify response metadata.
+                    if (end_error := metadata_run.end(None)) is not None:
+                        raise end_error
                     response_stream = iter([response])
                 case _server_shared.EndpointClientStreamSync():
                     response = endpoint.function(request_stream, ctx)
+                    if (end_error := metadata_run.end(None)) is not None:
+                        raise end_error
                     response_stream = iter([response])
                 case _server_shared.EndpointServerStreamSync():
                     request = _consume_single_request(request_stream)
@@ -497,9 +526,14 @@ class ConnectWSGIApplication(ABC):
             if first_response is None:
                 # It's valid for a service method to return no messages, finish the response
                 # without error.
+                error = metadata_run.end(None)
                 return [
                     _end_response(
-                        writer.end(ctx.response_trailers, None), send_trailers
+                        writer.end(
+                            ctx.response_trailers,
+                            ConnectWireError.from_exception(error) if error else None,
+                        ),
+                        send_trailers,
                     )
                 ]
 
@@ -509,21 +543,29 @@ class ConnectWSGIApplication(ABC):
             # been called in time. So we return the response stream as a separate generator
             # function. This means some duplication of error handling.
             return _response_stream(
-                first_response, environ, response_stream, writer, send_trailers, ctx
+                first_response,
+                environ,
+                response_stream,
+                writer,
+                send_trailers,
+                ctx,
+                metadata_run,
             )
         except Exception as e:  # noqa: BLE001 # invoking user callback
             # Exception before any response message was returned. An error after the first
             # response message will be handled by _response_stream, so here we have a
             # full error-only response.
+            error = metadata_run.end(e)
+            assert error is not None  # noqa: S101 # end never discards an error
             _drain_request_body(environ)
-            _maybe_log_exception(environ, e)
+            _maybe_log_exception(environ, error)
             _send_stream_response_headers(
                 start_response, protocol, codec, resp_compression.name(), ctx
             )
             return [
                 _end_response(
                     writer.end(
-                        ctx.response_trailers, ConnectWireError.from_exception(e)
+                        ctx.response_trailers, ConnectWireError.from_exception(error)
                     ),
                     send_trailers,
                 )
@@ -608,6 +650,7 @@ def _response_stream(
     writer: EnvelopeWriter,
     send_trailers: Callable[[list[tuple[str, str]]], None] | None,
     ctx: RequestContext,
+    metadata_run: MetadataInterceptorsRunSync,
 ) -> Iterable[bytes]:
     error: Exception | None = None
     try:
@@ -619,6 +662,10 @@ def _response_stream(
     except Exception as e:  # noqa: BLE001 # invoking user callback
         error = e
         _drain_request_body(environ)
+    finally:
+        # End the run before ending the response so on_end can still modify
+        # response trailers. This is a no-op if the run already ended.
+        error = metadata_run.end(error)
 
     yield _end_response(
         writer.end(

--- a/test/test_interceptor.py
+++ b/test/test_interceptor.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from pyqwest import Client, SyncClient
 from pyqwest.testing import ASGITransport, WSGITransport
 
+from connectrpc.client import ResponseMetadata
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
@@ -400,6 +401,309 @@ def test_intercept_bidi_stream_sync(
     ]
     assert client_interceptor.result == ["Hello MakeVariousHats and goodbye"]
     assert server_interceptor.result == ["Hello MakeVariousHats and goodbye"]
+
+
+class _CountingHaberdasher(Haberdasher):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def make_hat(self, request, _ctx):
+        self.calls += 1
+        return Hat(size=request.inches)
+
+    async def make_similar_hats(self, request, _ctx):
+        self.calls += 1
+        yield Hat(size=request.inches)
+
+
+class _CountingHaberdasherSync(HaberdasherSync):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def make_hat(self, request, _ctx):
+        self.calls += 1
+        return Hat(size=request.inches)
+
+    def make_similar_hats(self, request, _ctx):
+        self.calls += 1
+        yield Hat(size=request.inches)
+
+
+class _PassthroughUnaryInterceptor:
+    async def intercept_unary(self, call_next, request, ctx):
+        return await call_next(request, ctx)
+
+    def intercept_unary_sync(self, call_next, request, ctx):
+        return call_next(request, ctx)
+
+
+_MAKE_HAT_URL = "http://localhost/connectrpc.example.Haberdasher/MakeHat"
+_MAKE_SIMILAR_HATS_URL = (
+    "http://localhost/connectrpc.example.Haberdasher/MakeSimilarHats"
+)
+# A one-byte envelope containing invalid JSON.
+_INVALID_STREAM_BODY = b"\x00" + (1).to_bytes(4, "big") + b"{"
+
+
+@pytest.mark.asyncio
+async def test_metadata_interceptor_unparseable_unary_async(
+    server_interceptor: RequestInterceptor,
+) -> None:
+    """Leading metadata interceptors are invoked even if the message can't be parsed."""
+    service = _CountingHaberdasher()
+    trailing_interceptor = RequestInterceptor()
+    app = HaberdasherASGIApplication(
+        service,
+        interceptors=(
+            server_interceptor,
+            _PassthroughUnaryInterceptor(),
+            trailing_interceptor,
+        ),
+    )
+    client = Client(transport=ASGITransport(app))
+
+    res = await client.post(
+        _MAKE_HAT_URL, content=b"{", headers={"content-type": "application/json"}
+    )
+
+    assert res.status != 200
+    assert service.calls == 0
+    assert len(server_interceptor.result) == 1
+    assert server_interceptor.result[0].startswith(
+        "Hello MakeHat and goodbye with error"
+    )
+    # A metadata interceptor after a message interceptor is invoked within the
+    # chain, so it never runs if the message can't be parsed.
+    assert trailing_interceptor.result == []
+
+
+def test_metadata_interceptor_unparseable_unary_sync(
+    server_interceptor: RequestInterceptor,
+) -> None:
+    """Leading metadata interceptors are invoked even if the message can't be parsed."""
+    service = _CountingHaberdasherSync()
+    trailing_interceptor = RequestInterceptor()
+    app = HaberdasherWSGIApplication(
+        service,
+        interceptors=(
+            server_interceptor,
+            _PassthroughUnaryInterceptor(),
+            trailing_interceptor,
+        ),
+    )
+    client = SyncClient(transport=WSGITransport(app))
+
+    res = client.post(
+        _MAKE_HAT_URL, content=b"{", headers={"content-type": "application/json"}
+    )
+
+    assert res.status != 200
+    assert service.calls == 0
+    assert len(server_interceptor.result) == 1
+    assert server_interceptor.result[0].startswith(
+        "Hello MakeHat and goodbye with error"
+    )
+    assert trailing_interceptor.result == []
+
+
+@pytest.mark.asyncio
+async def test_metadata_interceptor_unparseable_stream_async(
+    server_interceptor: RequestInterceptor,
+) -> None:
+    """Leading metadata interceptors are invoked even if a stream message can't be parsed."""
+    service = _CountingHaberdasher()
+    app = HaberdasherASGIApplication(service, interceptors=(server_interceptor,))
+    client = Client(transport=ASGITransport(app))
+
+    res = await client.post(
+        _MAKE_SIMILAR_HATS_URL,
+        content=_INVALID_STREAM_BODY,
+        headers={"content-type": "application/connect+json"},
+    )
+
+    assert res.status == 200
+    assert service.calls == 0
+    assert len(server_interceptor.result) == 1
+    assert server_interceptor.result[0].startswith(
+        "Hello MakeSimilarHats and goodbye with error"
+    )
+
+
+def test_metadata_interceptor_unparseable_stream_sync(
+    server_interceptor: RequestInterceptor,
+) -> None:
+    """Leading metadata interceptors are invoked even if a stream message can't be parsed."""
+    service = _CountingHaberdasherSync()
+    app = HaberdasherWSGIApplication(service, interceptors=(server_interceptor,))
+    client = SyncClient(transport=WSGITransport(app))
+
+    res = client.post(
+        _MAKE_SIMILAR_HATS_URL,
+        content=_INVALID_STREAM_BODY,
+        headers={"content-type": "application/connect+json"},
+    )
+
+    assert res.status == 200
+    assert service.calls == 0
+    assert len(server_interceptor.result) == 1
+    assert server_interceptor.result[0].startswith(
+        "Hello MakeSimilarHats and goodbye with error"
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_interceptor_ordering_async() -> None:
+    """A leading metadata interceptor wraps message interceptors after it."""
+    events: list[str] = []
+
+    class EventMetadataInterceptor:
+        async def on_start(self, ctx):  # noqa: ARG002
+            events.append("metadata start")
+
+        async def on_end(self, _token, _ctx, _error):
+            events.append("metadata end")
+
+    class EventUnaryInterceptor:
+        async def intercept_unary(self, call_next, request, ctx):
+            events.append("unary before")
+            try:
+                return await call_next(request, ctx)
+            finally:
+                events.append("unary after")
+
+    class SimpleHaberdasher(Haberdasher):
+        async def make_hat(self, request, _ctx):
+            events.append("handler")
+            return Hat(size=request.inches)
+
+    app = HaberdasherASGIApplication(
+        SimpleHaberdasher(),
+        interceptors=(EventMetadataInterceptor(), EventUnaryInterceptor()),
+    )
+    async with HaberdasherClient(
+        "http://localhost", http_client=Client(transport=ASGITransport(app))
+    ) as client:
+        await client.make_hat(Size(inches=10))
+
+    assert events == [
+        "metadata start",
+        "unary before",
+        "handler",
+        "unary after",
+        "metadata end",
+    ]
+
+
+def test_metadata_interceptor_ordering_sync() -> None:
+    """A leading metadata interceptor wraps message interceptors after it."""
+    events: list[str] = []
+
+    class EventMetadataInterceptorSync:
+        def on_start_sync(self, _ctx):
+            events.append("metadata start")
+
+        def on_end_sync(self, _token, _ctx, _error):
+            events.append("metadata end")
+
+    class EventUnaryInterceptorSync:
+        def intercept_unary_sync(self, call_next, request, ctx):
+            events.append("unary before")
+            try:
+                return call_next(request, ctx)
+            finally:
+                events.append("unary after")
+
+    class SimpleHaberdasherSync(HaberdasherSync):
+        def make_hat(self, request, _ctx):
+            events.append("handler")
+            return Hat(size=request.inches)
+
+    app = HaberdasherWSGIApplication(
+        SimpleHaberdasherSync(),
+        interceptors=(EventMetadataInterceptorSync(), EventUnaryInterceptorSync()),
+    )
+    with HaberdasherClientSync(
+        "http://localhost", http_client=SyncClient(WSGITransport(app))
+    ) as client:
+        client.make_hat(Size(inches=10))
+
+    assert events == [
+        "metadata start",
+        "unary before",
+        "handler",
+        "unary after",
+        "metadata end",
+    ]
+
+
+class _ResponseMetadataInterceptor:
+    async def on_start(self, ctx):
+        return self.on_start_sync(ctx)
+
+    async def on_end(self, token, ctx, error) -> None:
+        self.on_end_sync(token, ctx, error)
+
+    def on_start_sync(self, _ctx) -> None:
+        return None
+
+    def on_end_sync(self, _token, ctx, _error) -> None:
+        ctx.response_headers.add("x-interceptor", "ran")
+        ctx.response_trailers.add("x-interceptor-trailer", "ran")
+
+
+@pytest.mark.asyncio
+async def test_metadata_interceptor_response_metadata_async() -> None:
+    """Response metadata set in on_end is still sent to the client."""
+
+    class SimpleHaberdasher(Haberdasher):
+        async def make_hat(self, request, _ctx):
+            return Hat(size=request.inches)
+
+        async def make_similar_hats(self, request, _ctx):
+            yield Hat(size=request.inches)
+
+    app = HaberdasherASGIApplication(
+        SimpleHaberdasher(), interceptors=(_ResponseMetadataInterceptor(),)
+    )
+    async with HaberdasherClient(
+        "http://localhost", http_client=Client(transport=ASGITransport(app))
+    ) as client:
+        with ResponseMetadata() as resp:
+            await client.make_hat(Size(inches=10))
+        assert resp.headers.get("x-interceptor") == "ran"
+        assert resp.trailers.get("x-interceptor-trailer") == "ran"
+
+        with ResponseMetadata() as resp:
+            async for _ in client.make_similar_hats(Size(inches=10)):
+                pass
+        assert resp.trailers.get("x-interceptor-trailer") == "ran"
+
+
+def test_metadata_interceptor_response_metadata_sync() -> None:
+    """Response metadata set in on_end is still sent to the client."""
+
+    class SimpleHaberdasherSync(HaberdasherSync):
+        def make_hat(self, request, _ctx):
+            return Hat(size=request.inches)
+
+        def make_similar_hats(self, request, _ctx):
+            yield Hat(size=request.inches)
+
+    app = HaberdasherWSGIApplication(
+        SimpleHaberdasherSync(), interceptors=(_ResponseMetadataInterceptor(),)
+    )
+    with HaberdasherClientSync(
+        "http://localhost", http_client=SyncClient(WSGITransport(app))
+    ) as client:
+        with ResponseMetadata() as resp:
+            client.make_hat(Size(inches=10))
+        assert resp.headers.get("x-interceptor") == "ran"
+        assert resp.trailers.get("x-interceptor-trailer") == "ran"
+
+        with ResponseMetadata() as resp:
+            for _ in client.make_similar_hats(Size(inches=10)):
+                pass
+        assert resp.trailers.get("x-interceptor-trailer") == "ran"
 
 
 def test_intercept_bidi_stream_sync_error(


### PR DESCRIPTION
Even though metadata interceptors don't need the request payload, they are always executed after parsing it. While we recommend using ASGI middleware for i.e. auth, still it's not that hard for us to also allow leading metadata interceptors to run before parse and can make sure an interceptor can block a bad / malicious request before parsing it if a user chooses to do it in an interceptor.